### PR TITLE
Do not hard-code pipelineSdkVersion in pipeline

### DIFF
--- a/s4sdk-pipeline.groovy
+++ b/s4sdk-pipeline.groovy
@@ -1,7 +1,5 @@
 #!/usr/bin/env groovy
 
-final def pipelineSdkVersion = 'master'
-
 pipeline {
     agent any
     options {
@@ -14,7 +12,7 @@ pipeline {
         stage('Init') {
             steps {
                 milestone 10
-                library "s4sdk-pipeline-library@${pipelineSdkVersion}"
+                library "s4sdk-pipeline-library"
                 stageInitS4sdkPipeline script: this
                 abortOldBuilds script: this
             }


### PR DESCRIPTION
Do not hard-code pipelineSdkVersion in order to allow control of the version from -
 * jenkins.yml, or
 * Manage Jenkins / Configure System / Global Pipeline Libraries.
This makes it easier to switch to a custom (forked) version of the library, where the version is e.g. 'patch-1'.
Currently when trying to force a version with 'Allow default version to be overridden' off, there is an error in the 'Init' stage:
"Version override not permitted for library s4sdk-pipeline-library".

## Context

If applied, this commit will allow the control of the s4sdk-pipeline-library version from jenkins.yml, or 'Manage Jenkins / Configure System / Global Pipeline Libraries'.

## Definition of Done
Please consider all items and remove only if not applicable.

- [*] I carefully reviewed my own pull request before assigning someone.
- [-] Changes to the configuration are also documented in the [configuration.md](https://github.com/SAP/cloud-s4-sdk-pipeline/blob/master/configuration.md)	
- [-] Pipeline config schema is updated [in schema store](https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/cloud-sdk-pipeline-config-schema.json)
- [-] Important design decisions are documented as an [ADR](https://github.com/SAP/cloud-s4-sdk-pipeline/tree/master/doc/architecture/decisions)
- [-] There are tests covering this change
- [-] This change is operations-relevant and I have updated the operations guide correspondingly

## Merging
Please use squash merge and provide a good commit message, e.g. inspired by the context above. 
Make sure to remove the reference to this pull request and that this template is not part of the commit message.
Also, please ensure the commit message is not just a list of "WIP" commit messages.
