### PR TITLE
Document groupId parameter for nexus config

### DIFF
--- a/configuration.md
+++ b/configuration.md
@@ -507,6 +507,7 @@ productionDeployment:
 | `version` | | `nexus3` | Version of nexus. Can be `nexus2` or `nexus3`. |
 | `url` | X | | URL of the nexus. The scheme part of the URL will not be considered, because only `http` is supported. |
 | `repository` | X | | Name of the nexus repository. |
+| `groupId` | | | Common group ID for MTA build artifacts, ignored for Maven projects. |
 | `additionalClassifiers` | | | List of additional classifiers that should be deployed to nexus. Each item is a map of a type and a classifier name.|
 | `credentialsId` | | | ID to the credentials which is used to connect to Nexus. Anonymous deployments do not require a `credentialsId`.|
 


### PR DESCRIPTION
## Context

Document groupId parameter for nexus config, as it is in fact necessary for MTA projects.

## Definition of Done
Please consider all items and remove only if not applicable.

- [x] I carefully reviewed my own pull request before assigning someone.
- [ ] Pipeline config schema is updated [in schema store](https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/cloud-sdk-pipeline-config-schema.json) -> [PR is open](https://github.com/SchemaStore/schemastore/pull/985)